### PR TITLE
Extract randomness to tests

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -1,11 +1,6 @@
-resource "random_pet" "name" {
-  length = "1"
-  prefix = "${var.organization_name}"
-}
-
 resource "google_compute_network" "main" {
-  name                    = "${random_pet.name.id}"
-  description             = "${random_pet.name.id} network"
+  name                    = "${var.organization_name}"
+  description             = "${var.organization_name} network"
   auto_create_subnetworks = false
 }
 

--- a/test/fixtures/tf_module/main.tf
+++ b/test/fixtures/tf_module/main.tf
@@ -13,7 +13,12 @@ provider "random" {
   version = "~> 1.0"
 }
 
+resource "random_pet" "name" {
+  length = "1"
+  prefix = "test-org"
+}
+
 module "network" {
-  organization_name = "test-org"
+  organization_name = "${random_pet.name.id}"
   source            = "../../.."
 }


### PR DESCRIPTION
Extracting randomness to tests means tests can be executed concurrently by different sources while maintaining predictability of the module's behaviour.